### PR TITLE
Retry subscription event publisher

### DIFF
--- a/lib/commanded/event_store/adapters/spear/event_publisher.ex
+++ b/lib/commanded/event_store/adapters/spear/event_publisher.ex
@@ -69,7 +69,7 @@ defmodule Commanded.EventStore.Adapters.Spear.EventPublisher do
   end
 
   def handle_info(:retry, state) do
-    {:ok, state, {:continue, :subscribe}}
+    {:noreply, state, {:continue, :subscribe}}
   end
 
   defp process_push(push, %State{serializer: serializer, pubsub: pubsub}) do

--- a/lib/commanded/event_store/adapters/spear/supervisor.ex
+++ b/lib/commanded/event_store/adapters/spear/supervisor.ex
@@ -29,6 +29,7 @@ defmodule Commanded.EventStore.Adapters.Spear.Supervisor do
 
     children = [
       {Registry, keys: :duplicate, name: pubsub_name, partitions: 1},
+      {Spear.Connection, Keyword.merge(spear_config, name: conn_name)},
       %{
         id: EventPublisher,
         start:
@@ -41,7 +42,6 @@ defmodule Commanded.EventStore.Adapters.Spear.Supervisor do
         shutdown: 5000,
         type: :worker
       },
-      {Spear.Connection, Keyword.merge(spear_config, name: conn_name)},
       {SubscriptionsSupervisor, name: subscriptions_name}
     ]
 


### PR DESCRIPTION
Closes #15 

Refactors event publisher to use `handle_continue`, changes the order of supervisor child to start `Spear.Connection` before `EventPublisher`