### PR TITLE
Improve writing and decoding of system events

### DIFF
--- a/lib/commanded/event_store/adapters/spear/mapper.ex
+++ b/lib/commanded/event_store/adapters/spear/mapper.ex
@@ -28,8 +28,8 @@ defmodule Commanded.EventStore.Adapters.Spear.Mapper do
             created: created
           },
           link: link
-        } = event,
-        serializer,
+        } = spear_event,
+        _serializer,
         stream_prefix
       ) do
     metadata = %{}
@@ -37,7 +37,7 @@ defmodule Commanded.EventStore.Adapters.Spear.Mapper do
     {causation_id, metadata} = Map.pop(metadata, "$causationId")
     {correlation_id, metadata} = Map.pop(metadata, "$correlationId")
 
-    event = %RecordedEvent{
+    recorded_event = %RecordedEvent{
       event_id: id,
       event_number: commit_position,
       stream_id: to_stream_id(stream_prefix, stream_name),
@@ -45,19 +45,17 @@ defmodule Commanded.EventStore.Adapters.Spear.Mapper do
       causation_id: causation_id,
       correlation_id: correlation_id,
       event_type: type,
-      data: event,
+      data: spear_event,
       metadata: metadata,
       created_at: created
     }
 
     if link do
-      link_payload = to_recorded_event(link, serializer, stream_prefix)
+      metadata = Map.put(recorded_event.metadata, :link, link)
 
-      metadata = Map.put(event.metadata, :link, link_payload)
-
-      %{event | metadata: metadata}
+      %{recorded_event | metadata: metadata}
     else
-      event
+      recorded_event
     end
   end
 
@@ -89,7 +87,7 @@ defmodule Commanded.EventStore.Adapters.Spear.Mapper do
     {causation_id, metadata} = Map.pop(metadata, "$causationId")
     {correlation_id, metadata} = Map.pop(metadata, "$correlationId")
 
-    event = %RecordedEvent{
+    recorded_event = %RecordedEvent{
       event_id: id,
       event_number: commit_position,
       stream_id: to_stream_id(stream_prefix, stream_name),
@@ -103,13 +101,11 @@ defmodule Commanded.EventStore.Adapters.Spear.Mapper do
     }
 
     if link do
-      link_payload = to_recorded_event(link, serializer, stream_prefix)
+      metadata = Map.put(recorded_event.metadata, :link, link)
 
-      metadata = Map.put(event.metadata, :link, link_payload)
-
-      %{event | metadata: metadata}
+      %{recorded_event | metadata: metadata}
     else
-      event
+      recorded_event
     end
   end
 

--- a/test/event_store/stream_test.exs
+++ b/test/event_store/stream_test.exs
@@ -96,10 +96,10 @@ defmodule Commanded.EventStore.Adapters.Spear.StreamTest do
              metadata: %{link: link}
            } = first
 
-    assert %RecordedEvent{
-             stream_id: ^all_stream,
-             stream_version: 1,
-             event_type: "$>"
+    assert %Spear.Event{
+             type: "$>",
+             link: nil,
+             metadata: %{stream_name: ^all_stream, stream_revision: 0}
            } = link
 
     assert %RecordedEvent{
@@ -108,10 +108,10 @@ defmodule Commanded.EventStore.Adapters.Spear.StreamTest do
              metadata: %{link: link}
            } = second
 
-    assert %RecordedEvent{
-             stream_id: ^all_stream,
-             stream_version: 2,
-             event_type: "$>"
+    assert %Spear.Event{
+             type: "$>",
+             link: nil,
+             metadata: %{stream_name: ^all_stream, stream_revision: 1}
            } = link
   end
 

--- a/test/event_store/stream_test.exs
+++ b/test/event_store/stream_test.exs
@@ -20,14 +20,21 @@ defmodule Commanded.EventStore.Adapters.Spear.StreamTest do
              SpearAdapter.append_to_stream(event_store_meta, stream, 0, [
                %EventData{
                  event_type: event_type,
-                 data: data,
-                 metadata: %{content_type: "application/octet-stream"}
+                 data: data
                }
              ])
 
-    assert [%RecordedEvent{event_type: ^event_type, data: %Spear.Event{body: ^data}}] =
+    assert [
+             %RecordedEvent{
+               event_type: ^event_type,
+               data: %Spear.Event{body: ^data},
+               metadata: metadata
+             }
+           ] =
              SpearAdapter.stream_forward(event_store_meta, stream)
              |> Enum.to_list()
+
+    assert metadata == %{}
   end
 
   test "should read from the all stream properly", %{event_store_meta: event_store_meta} do

--- a/test/event_store/stream_test.exs
+++ b/test/event_store/stream_test.exs
@@ -10,6 +10,26 @@ defmodule Commanded.EventStore.Adapters.Spear.StreamTest do
     defstruct [:name]
   end
 
+  test "override content type", %{event_store_meta: event_store_meta} do
+    stream = Test.UUID.uuid4()
+
+    event_type = "$>"
+    data = "hello world"
+
+    assert :ok =
+             SpearAdapter.append_to_stream(event_store_meta, stream, 0, [
+               %EventData{
+                 event_type: event_type,
+                 data: data,
+                 metadata: %{content_type: "application/octet-stream"}
+               }
+             ])
+
+    assert [%RecordedEvent{event_type: ^event_type, data: %Spear.Event{body: ^data}}] =
+             SpearAdapter.stream_forward(event_store_meta, stream)
+             |> Enum.to_list()
+  end
+
   test "should read from the all stream properly", %{event_store_meta: event_store_meta} do
     event = fn name ->
       %EventData{


### PR DESCRIPTION
This PR includes the following:

- Do not use the default content type when writing system events (i.e., events of type `$>`)
- Do not decode link events as `RecordedEvent` but directly as `Spear.Event`