### PR TITLE
Make sure to read the last snapshot and fix deserializing data

### DIFF
--- a/lib/commanded/event_store/adapters/spear/mapper.ex
+++ b/lib/commanded/event_store/adapters/spear/mapper.ex
@@ -140,7 +140,8 @@ defmodule Commanded.EventStore.Adapters.Spear.Mapper do
     |> Spear.Event.to_proposed_message(%{serializer_content_type => &serializer.serialize/1})
   end
 
-  def to_snapshot_data(%RecordedEvent{data: %SnapshotData{} = snapshot} = event) do
+  def to_snapshot_data(%RecordedEvent{data: %SnapshotData{} = snapshot} = event)
+      when is_struct(snapshot.data) do
     %SnapshotData{snapshot | created_at: event.created_at}
   end
 

--- a/lib/commanded/event_store/spear.ex
+++ b/lib/commanded/event_store/spear.ex
@@ -179,7 +179,7 @@ defmodule Commanded.EventStore.Adapters.Spear do
 
     Logger.debug(fn -> "Spear event store read snapshot from stream: " <> inspect(stream) end)
 
-    case execute_read(adapter_meta, stream, :start, 1, :backwards) do
+    case execute_read(adapter_meta, stream, :end, 1, :backwards) do
       {:ok, stream} ->
         case Enum.take(stream, 1) do
           [recorded_event] -> {:ok, Mapper.to_snapshot_data(recorded_event)}

--- a/test/event_store/snapshot_test.exs
+++ b/test/event_store/snapshot_test.exs
@@ -22,4 +22,21 @@ defmodule Commanded.EventStore.Adapters.Spear.SnapshotTest do
     assert %{data: data} = snapshot
     assert %BankAccountOpened{account_number: 100, initial_balance: :foo} = data
   end
+
+  test "works with json serializer", %{
+    event_store: event_store,
+    event_store_meta: event_store_meta
+  } do
+    event_store_meta =
+      event_store_meta
+      |> Map.replace!(:serializer, Commanded.Serialization.JsonSerializer)
+      |> Map.put(:content_type, "application/json")
+
+    snapshot = build_snapshot_data(100)
+    assert :ok = event_store.record_snapshot(event_store_meta, snapshot)
+
+    {:ok, snapshot} = event_store.read_snapshot(event_store_meta, snapshot.source_uuid)
+    assert %{data: data} = snapshot
+    assert %BankAccountOpened{account_number: 100} = data
+  end
 end


### PR DESCRIPTION
Issue 1: Even though the combination of `start` and `backwards` seems to make sense, this implementation was not correct. The EventStore returns the first snapshot in this case instead of the last snapshot. Unfortunately this doesn't seem to be covered by the Commanded Testsuite.

Issue 2: The snapshot.data was not decoded to a struct but just to a map, which caused the ProcessManager to not match any of the `handle` clauses.